### PR TITLE
Workaround build error

### DIFF
--- a/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -204,7 +204,8 @@
     }
 
     .trix-content a[href^="bullettrain://"] {
-      @apply text-white bg-darkPrimary-500;
+      @apply bg-darkPrimary-500;
+      font-color: #fff !important;
     }
 
     /* CKEditor */


### PR DESCRIPTION
This rule is exploding in bullet during `yarn build:css`.

```
CssSyntaxError: /Users/ship/src/prefab/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css:208:7: Missed semicolon
```
